### PR TITLE
Set GOPATH to a root go directory.

### DIFF
--- a/1.11/Dockerfile
+++ b/1.11/Dockerfile
@@ -1,22 +1,22 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/base:2019.07
+FROM cimg/base:2019.10
 
 LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
 
 # Install packages needed for CGO
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		g++ \
-		libc6-dev \
-	&& rm -rf /var/lib/apt/lists/*
+		libc6-dev && \
+	rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION=1.11.13
-ENV GO_SHA=fake-sha
+ENV GO_SHA=
 
-RUN curl -sSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar -xz -C /usr/local/
+RUN curl -sSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar -xz -C /usr/local/ && \
+	mkdir -p /go/bin
 
-# We need to check the SHA here. This isn't done yet.
-
+ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
 WORKDIR /root/project

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,22 +1,22 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/%%PARENT%%:2019.07
+FROM cimg/%%PARENT%%:2019.10
 
 LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
 
 # Install packages needed for CGO
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		g++ \
-		libc6-dev \
-	&& rm -rf /var/lib/apt/lists/*
+		libc6-dev && \
+	rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION=%%MAIN_VERSION%%
 ENV GO_SHA=%%MAIN_SHA%%
 
-RUN curl -sSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar -xz -C /usr/local/
+RUN curl -sSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar -xz -C /usr/local/ && \
+	mkdir -p /go/bin
 
-# We need to check the SHA here. This isn't done yet.
-
+ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
 WORKDIR /root/project

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker build --file 1.13/Dockerfile -t cimg/go:1.13.1  -t cimg/go:1.13 .
+docker build --file 1.11/Dockerfile -t cimg/go:1.11.13  -t cimg/go:1.11 .


### PR DESCRIPTION
While the default working directory won't place users in the GOPATH, it
will still be useful to have around for older projects who want to use
it.

This creates a directory to serve as the `GOPATH`, `/go`. The latest point release of both Go v1.11 and v1.12 (1.11.13 and 1.12.10) as well as all releases of Go v1.13 will receive this change.

Fixes #25