### PR TITLE
Publish v1.13.12 and v1.14.4. [release]

### DIFF
--- a/1.13/Dockerfile
+++ b/1.13/Dockerfile
@@ -1,11 +1,10 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/base:2020.05
+FROM cimg/base:2020.06
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV GO_VERSION=1.13.11
-ENV GO_SHA=
+ENV GO_VERSION=1.13.12
 
 # Install packages needed for CGO
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \

--- a/1.13/node/Dockerfile
+++ b/1.13/node/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/go:1.13.11
+FROM cimg/go:1.13.12
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/1.14/Dockerfile
+++ b/1.14/Dockerfile
@@ -1,11 +1,10 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/base:2020.05
+FROM cimg/base:2020.06
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV GO_VERSION=1.14.3
-ENV GO_SHA=
+ENV GO_VERSION=1.14.4
 
 # Install packages needed for CGO
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \

--- a/1.14/node/Dockerfile
+++ b/1.14/node/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/go:1.14.3
+FROM cimg/go:1.14.4
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,11 +1,10 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/%%PARENT%%:2020.05
+FROM cimg/%%PARENT%%:2020.06
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
 ENV GO_VERSION=%%MAIN_VERSION%%
-ENV GO_SHA=%%MAIN_SHA%%
 
 # Install packages needed for CGO
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-docker build --file 1.13/Dockerfile -t cimg/go:1.13.11  -t cimg/go:1.13 .
-docker build --file 1.13/node/Dockerfile -t cimg/go:1.13.11-node  -t cimg/go:1.13-node .
-docker build --file 1.14/Dockerfile -t cimg/go:1.14.3  -t cimg/go:1.14 .
-docker build --file 1.14/node/Dockerfile -t cimg/go:1.14.3-node  -t cimg/go:1.14-node .
+docker build --file 1.13/Dockerfile -t cimg/go:1.13.12  -t cimg/go:1.13 .
+docker build --file 1.13/node/Dockerfile -t cimg/go:1.13.12-node  -t cimg/go:1.13-node .
+docker build --file 1.14/Dockerfile -t cimg/go:1.14.4  -t cimg/go:1.14 .
+docker build --file 1.14/node/Dockerfile -t cimg/go:1.14.4-node  -t cimg/go:1.14-node .


### PR DESCRIPTION
- two new releases
- removed HASH envar which was unused
- June snapshot for base image