### PR TITLE
proposal: add go 1.15-rc2 to the public images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,9 @@ jobs:
           name: "Publish Docker Images (master branch only)"
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              
+
               echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
-              
+
               # an else block will be added in the future for a staging release
               if git log -1 --pretty=%s | grep "\[release\]"; then
                 echo "Publishing cimg/go to Docker Hub production."

--- a/1.15/Dockerfile
+++ b/1.15/Dockerfile
@@ -1,0 +1,21 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/base:2020.06
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+ENV GO_VERSION=1.15rc2
+
+# Install packages needed for CGO
+RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+		g++ \
+		libc6-dev && \
+	sudo rm -rf /var/lib/apt/lists/* && \
+	curl -sSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | sudo tar -xz -C /usr/local/ && \
+	mkdir -p /home/circleci/go/bin
+
+RUN curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v0.5.2/gotestsum_0.5.2_linux_amd64.tar.gz" | \
+	sudo tar -xz -C /usr/local/bin gotestsum
+
+ENV GOPATH /home/circleci/go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH

--- a/1.15/node/Dockerfile
+++ b/1.15/node/Dockerfile
@@ -1,0 +1,20 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/go:1.15rc2
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Dockerfile will pull the latest LTS release from cimg-node.
+RUN curl -sSL "https://raw.githubusercontent.com/CircleCI-Public/cimg-node/master/ALIASES" -o nodeAliases.txt && \
+	NODE_VERSION=$(grep "lts" ./nodeAliases.txt | cut -d "=" -f 2-) && \
+	curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
+	sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
+	rm node.tar.xz nodeAliases.txt && \
+	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+ENV YARN_VERSION 1.22.4
+RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
+	sudo tar -xzf yarn.tar.gz -C /opt/ && \
+	rm yarn.tar.gz && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg

--- a/build-images.sh
+++ b/build-images.sh
@@ -4,3 +4,5 @@ docker build --file 1.13/Dockerfile -t cimg/go:1.13.15  -t cimg/go:1.13 .
 docker build --file 1.13/node/Dockerfile -t cimg/go:1.13.15-node  -t cimg/go:1.13-node .
 docker build --file 1.14/Dockerfile -t cimg/go:1.14.7  -t cimg/go:1.14 .
 docker build --file 1.14/node/Dockerfile -t cimg/go:1.14.7-node  -t cimg/go:1.14-node .
+docker build --file 1.15/Dockerfile -t cimg/go:1.15rc2  -t cimg/go:1.15  .
+docker build --file 1.15/node/Dockerfile -t cimg/go:1.15rc2-node  -t cimg/go:1.15-node .


### PR DESCRIPTION
This PR adds a proposal to have the go 1.15rc2 in the circleci public images. So users of Circleci can start to experiment the new version

if makes no sense, feel free to close.
thanks!