### PR TITLE
Publish v1.14.8 and v1.15.1. [release]

### DIFF
--- a/1.14/Dockerfile
+++ b/1.14/Dockerfile
@@ -4,7 +4,7 @@ FROM cimg/base:2020.06
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV GO_VERSION=1.14.7
+ENV GO_VERSION=1.14.8
 
 # Install packages needed for CGO
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \

--- a/1.14/node/Dockerfile
+++ b/1.14/node/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/go:1.14.7
+FROM cimg/go:1.14.8
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/1.15/Dockerfile
+++ b/1.15/Dockerfile
@@ -4,7 +4,7 @@ FROM cimg/base:2020.06
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV GO_VERSION=1.15
+ENV GO_VERSION=1.15.1
 
 # Install packages needed for CGO
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \

--- a/1.15/node/Dockerfile
+++ b/1.15/node/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/go:1.15
+FROM cimg/go:1.15.1
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
-docker build --file 1.15/Dockerfile -t cimg/go:1.15 .
-docker build --file 1.15/node/Dockerfile -t cimg/go:1.15-node .
+docker build --file 1.14/Dockerfile -t cimg/go:1.14.8  -t cimg/go:1.14 .
+docker build --file 1.14/node/Dockerfile -t cimg/go:1.14.8-node  -t cimg/go:1.14-node .
+docker build --file 1.15/Dockerfile -t cimg/go:1.15.1 -t cimg/go:1.15 .
+docker build --file 1.15/node/Dockerfile -t cimg/go:1.15.1-node -t cimg/go:1.15-node .


### PR DESCRIPTION
Security releases for go 1.14 and 1.15.

See https://groups.google.com/g/golang-announce/c/8wqlSbkLdPs/m/UccMwBPUBAAJ for more details