### PR TITLE
Publish v1.16.13 and v1.17.6. [release]

### DIFF
--- a/1.16/Dockerfile
+++ b/1.16/Dockerfile
@@ -1,10 +1,10 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/base:2021.10
+FROM cimg/base:2022.01
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV GO_VERSION=1.16.12
+ENV GO_VERSION=1.16.13
 
 # Install packages needed for CGO
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \

--- a/1.16/browsers/Dockerfile
+++ b/1.16/browsers/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/go:1.16.12-node
+FROM cimg/go:1.16.13-node
 
 LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/1.16/node/Dockerfile
+++ b/1.16/node/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/go:1.16.12
+FROM cimg/go:1.16.13
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/1.17/Dockerfile
+++ b/1.17/Dockerfile
@@ -1,10 +1,10 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/base:2021.10
+FROM cimg/base:2022.01
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV GO_VERSION=1.17.5
+ENV GO_VERSION=1.17.6
 
 # Install packages needed for CGO
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \

--- a/1.17/browsers/Dockerfile
+++ b/1.17/browsers/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/go:1.17.5-node
+FROM cimg/go:1.17.6-node
 
 LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/1.17/node/Dockerfile
+++ b/1.17/node/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/go:1.17.5
+FROM cimg/go:1.17.6
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/%%PARENT%%:2021.10
+FROM cimg/%%PARENT%%:2022.01
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-docker build --file 1.16/Dockerfile -t cimg/go:1.16.12  -t cimg/go:1.16 .
-docker build --file 1.16/node/Dockerfile -t cimg/go:1.16.12-node  -t cimg/go:1.16-node .
-docker build --file 1.16/browsers/Dockerfile -t cimg/go:1.16.12-browsers  -t cimg/go:1.16-browsers .
-docker build --file 1.17/Dockerfile -t cimg/go:1.17.5  -t cimg/go:1.17 .
-docker build --file 1.17/node/Dockerfile -t cimg/go:1.17.5-node  -t cimg/go:1.17-node .
-docker build --file 1.17/browsers/Dockerfile -t cimg/go:1.17.5-browsers  -t cimg/go:1.17-browsers .
+docker build --file 1.16/Dockerfile -t cimg/go:1.16.13  -t cimg/go:1.16 .
+docker build --file 1.16/node/Dockerfile -t cimg/go:1.16.13-node  -t cimg/go:1.16-node .
+docker build --file 1.16/browsers/Dockerfile -t cimg/go:1.16.13-browsers  -t cimg/go:1.16-browsers .
+docker build --file 1.17/Dockerfile -t cimg/go:1.17.6  -t cimg/go:1.17 .
+docker build --file 1.17/node/Dockerfile -t cimg/go:1.17.6-node  -t cimg/go:1.17-node .
+docker build --file 1.17/browsers/Dockerfile -t cimg/go:1.17.6-browsers  -t cimg/go:1.17-browsers .


### PR DESCRIPTION
Also bumps the base image to the next quarterly release, January 2022.