### PR TITLE
Fix missing push script [release]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
               # an else block will be added in the future for a staging release
               if git log -1 --pretty=%s | grep "\[release\]"; then
                 echo "Publishing cimg/go to Docker Hub production."
-                docker push cimg/go
+                ./push-images.sh
               else
                 echo "Skipping publishing."
               fi


### PR DESCRIPTION
The push script was missing, causing a release failure. This applies the script and tries again to release #154.