### PR TITLE
Publish v1.17.9 and v1.18.1. [release]

### DIFF
--- a/1.17/Dockerfile
+++ b/1.17/Dockerfile
@@ -2,23 +2,27 @@
 
 # Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
 
-FROM cimg/base:2022.01
+FROM cimg/base:2022.04
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV GO_VERSION=1.17.8
+ENV GO_VER="1.17.9"
 
 # Install packages needed for CGO
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		g++ \
 		libc6-dev && \
 	sudo rm -rf /var/lib/apt/lists/* && \
-	curl -sSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | sudo tar -xz -C /usr/local/ && \
+	# Check if we're facing the first minor release issue and adjust if needed
+	if [[ ${GO_VER:(-2)} == ".0" ]]; then \
+	  GO_VER=${GO_VER:0:-2}; \
+	fi && \
+	curl -sSL "https://golang.org/dl/go${GO_VER}.linux-amd64.tar.gz" | sudo tar -xz -C /usr/local/ && \
 	mkdir -p /home/circleci/go/bin
 
 # Install related tools
 ENV GOTESTSUM_V=1.7.0
-ENV GOCI_LINT_V=1.43.0
+ENV GOCI_LINT_V=1.45.2
 RUN curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_V}/gotestsum_${GOTESTSUM_V}_linux_amd64.tar.gz" | \
 	sudo tar -xz -C /usr/local/bin gotestsum && \
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/local/bin v${GOCI_LINT_V}

--- a/1.17/browsers/Dockerfile
+++ b/1.17/browsers/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/go:1.17.8-node
+FROM cimg/go:1.17.9-node
 
 LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/1.17/node/Dockerfile
+++ b/1.17/node/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/go:1.17.8
+FROM cimg/go:1.17.9
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/1.18/Dockerfile
+++ b/1.18/Dockerfile
@@ -2,11 +2,11 @@
 
 # Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
 
-FROM cimg/base:2022.01
+FROM cimg/base:2022.04
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV GO_VER="1.18.0"
+ENV GO_VER="1.18.1"
 
 # Install packages needed for CGO
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \

--- a/1.18/browsers/Dockerfile
+++ b/1.18/browsers/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/go:1.18.0-node
+FROM cimg/go:1.18.1-node
 
 LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/1.18/node/Dockerfile
+++ b/1.18/node/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/go:1.18.0
+FROM cimg/go:1.18.1
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -2,7 +2,7 @@
 
 # Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
 
-FROM cimg/%%PARENT%%:2022.01
+FROM cimg/%%PARENT%%:2022.04
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Do not edit by hand; please use build scripts/templates to make changes
 
-docker build --file 1.10/Dockerfile -t cimg/go:1.10.8  -t cimg/go:1.10 .
-docker build --file 1.10/node/Dockerfile -t cimg/go:1.10.8-node  -t cimg/go:1.10-node .
-docker build --file 1.10/browsers/Dockerfile -t cimg/go:1.10.8-browsers  -t cimg/go:1.10-browsers .
+docker build --file 1.17/Dockerfile -t cimg/go:1.17.9  -t cimg/go:1.17 .
+docker build --file 1.17/node/Dockerfile -t cimg/go:1.17.9-node  -t cimg/go:1.17-node .
+docker build --file 1.17/browsers/Dockerfile -t cimg/go:1.17.9-browsers  -t cimg/go:1.17-browsers .
+docker build --file 1.18/Dockerfile -t cimg/go:1.18.1  -t cimg/go:1.18 .
+docker build --file 1.18/node/Dockerfile -t cimg/go:1.18.1-node  -t cimg/go:1.18-node .
+docker build --file 1.18/browsers/Dockerfile -t cimg/go:1.18.1-browsers  -t cimg/go:1.18-browsers .

--- a/push-images.sh
+++ b/push-images.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 # Do not edit by hand; please use build scripts/templates to make changes
 
-docker push cimg/go:1.10.8
-docker push cimg/go:1.10
-docker push cimg/go:1.10.8-node
-docker push cimg/go:1.10-node
-docker push cimg/go:1.10.8-browsers
-docker push cimg/go:1.10-browsers
+docker push cimg/go:1.17.9
+docker push cimg/go:1.17
+docker push cimg/go:1.17.9-node
+docker push cimg/go:1.17-node
+docker push cimg/go:1.17.9-browsers
+docker push cimg/go:1.17-browsers
+
+docker push cimg/go:1.18.1
+docker push cimg/go:1.18
+docker push cimg/go:1.18.1-node
+docker push cimg/go:1.18-node
+docker push cimg/go:1.18.1-browsers
+docker push cimg/go:1.18-browsers


### PR DESCRIPTION
- normal release
- updated the base image to the new quarterly image
- temporarily downgraded shared tools as it looks like we introduced a regression recently