### PR TITLE
add context and [release]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ workflows:
           working-dir: ./
           publish-branch: main
           image: cimg/go
+          context: cimg-publishing
   update-readme:
     when:
       equal: [main, << pipeline.git.branch >>]


### PR DESCRIPTION
the context for cimg-publishing was not included and therefore dockerhub credentials were not used to log in, preventing releases from being cut.

it was done in the test deployment configuration, which is why it was assumed to have been added in the first place