### PR TITLE
upgrade golangci-lint to 1.46.2

### DIFF
--- a/1.18/Dockerfile
+++ b/1.18/Dockerfile
@@ -22,7 +22,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 
 # Install related tools
 ENV GOTESTSUM_V=1.8.1
-ENV GOCI_LINT_V=1.45.2
+ENV GOCI_LINT_V=1.46.2
 RUN curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_V}/gotestsum_${GOTESTSUM_V}_linux_amd64.tar.gz" | \
 	sudo tar -xz -C /usr/local/bin gotestsum && \
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/local/bin v${GOCI_LINT_V}


### PR DESCRIPTION
Upgrade golangci-lint to 1.46.2.

With go.1.18 several linters were disabled because of the [lack of support on generics](https://github.com/golangci/golangci-lint/issues/2649).

staticcheck is a popular linter that has been [re-enabled recently](https://github.com/golangci/golangci-lint/commit/f5b92e1ae287828915d2bb42ff793fb714dfd28b). 

It would be great to have the tool in a recent version.