### PR TITLE
Update GolangCI Lint to v1.48.0 [release]

### DIFF
--- a/1.19/Dockerfile
+++ b/1.19/Dockerfile
@@ -21,8 +21,8 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	mkdir -p /home/circleci/go/bin
 
 # Install related tools
-ENV GOTESTSUM_V=1.8.1
-ENV GOCI_LINT_V=1.47.3
+ENV GOTESTSUM_V=1.8.2
+ENV GOCI_LINT_V=1.48.0
 RUN curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_V}/gotestsum_${GOTESTSUM_V}_linux_amd64.tar.gz" | \
 	sudo tar -xz -C /usr/local/bin gotestsum && \
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/local/bin v${GOCI_LINT_V}

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -22,7 +22,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 
 # Install related tools
 ENV GOTESTSUM_V=1.8.2
-ENV GOCI_LINT_V=1.47.3
+ENV GOCI_LINT_V=1.48.0
 RUN curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_V}/gotestsum_${GOTESTSUM_V}_linux_amd64.tar.gz" | \
 	sudo tar -xz -C /usr/local/bin gotestsum && \
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/local/bin v${GOCI_LINT_V}


### PR DESCRIPTION
Fixes #189 

This respins Go v1.19.0 as GolangCI-Lint is broken in the image.