### PR TITLE
Respin v1.18.7 and v1.19.2. [release]

### DIFF
--- a/1.18/Dockerfile
+++ b/1.18/Dockerfile
@@ -5,7 +5,9 @@
 # By policy, the base image tag should be a quarterly tag unless there's a 
 # specific reason to use a different one. This means January, April, July, or 
 # October.
-FROM cimg/base:2022.10
+
+# NOTE: The base image uses November due to a OpenSSL CVE. Will resume using quarterly images in Q1
+FROM cimg/base:2022.11
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/1.19/Dockerfile
+++ b/1.19/Dockerfile
@@ -5,7 +5,9 @@
 # By policy, the base image tag should be a quarterly tag unless there's a 
 # specific reason to use a different one. This means January, April, July, or 
 # October.
-FROM cimg/base:2022.10
+
+# NOTE: The base image uses November due to a OpenSSL CVE. Will resume using quarterly images in Q1
+FROM cimg/base:2022.11
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -5,7 +5,9 @@
 # By policy, the base image tag should be a quarterly tag unless there's a 
 # specific reason to use a different one. This means January, April, July, or 
 # October.
-FROM cimg/%%PARENT%%:2022.10
+
+# NOTE: The base image uses November due to a OpenSSL CVE. Will resume using quarterly images in Q1
+FROM cimg/%%PARENT%%:2022.11
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 


### PR DESCRIPTION
Respin of 1.18.7 and 1.19.2 due to OpenSSL CVE