### PR TITLE
Update GolangCI Lint to v1.51.2 and respin [release]

### DIFF
--- a/1.19/Dockerfile
+++ b/1.19/Dockerfile
@@ -25,7 +25,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 
 # Install related tools
 ENV GOTESTSUM_V=1.9.0
-ENV GOCI_LINT_V=1.51.1
+ENV GOCI_LINT_V=1.51.2
 RUN curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_V}/gotestsum_${GOTESTSUM_V}_linux_amd64.tar.gz" | \
 	sudo tar -xz -C /usr/local/bin gotestsum && \
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/local/bin v${GOCI_LINT_V}

--- a/1.20/Dockerfile
+++ b/1.20/Dockerfile
@@ -25,7 +25,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 
 # Install related tools
 ENV GOTESTSUM_V=1.9.0
-ENV GOCI_LINT_V=1.51.1
+ENV GOCI_LINT_V=1.51.2
 RUN curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_V}/gotestsum_${GOTESTSUM_V}_linux_amd64.tar.gz" | \
 	sudo tar -xz -C /usr/local/bin gotestsum && \
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/local/bin v${GOCI_LINT_V}

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -25,7 +25,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 
 # Install related tools
 ENV GOTESTSUM_V=1.9.0
-ENV GOCI_LINT_V=1.51.1
+ENV GOCI_LINT_V=1.51.2
 RUN curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_V}/gotestsum_${GOTESTSUM_V}_linux_amd64.tar.gz" | \
 	sudo tar -xz -C /usr/local/bin gotestsum && \
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/local/bin v${GOCI_LINT_V}


### PR DESCRIPTION
Closes #218.