### PR TITLE
Add arm64 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  cimg: circleci/cimg@0.3.0
+  cimg: circleci/cimg@0.3.1
   slack: circleci/slack@4.12.1
   gh: circleci/github-cli@2.2.0
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -20,13 +20,15 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	if [[ ${GO_VER:(-2)} == ".0" ]]; then \
 	  GO_VER=${GO_VER:0:-2}; \
 	fi && \
-	curl -sSL "https://go.dev/dl/go${GO_VER}.linux-amd64.tar.gz" | sudo tar -xz -C /usr/local/ && \
+	[[ $(uname -m) == "x86_64" ]] && ARCH="amd64" || ARCH="arm64" && \
+	curl -sSL "https://go.dev/dl/go${GO_VER}.linux-${ARCH}.tar.gz" | sudo tar -xz -C /usr/local/ && \
 	mkdir -p /home/circleci/go/bin
 
 # Install related tools
 ENV GOTESTSUM_V=1.10.0
 ENV GOCI_LINT_V=1.53.2
-RUN curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_V}/gotestsum_${GOTESTSUM_V}_linux_amd64.tar.gz" | \
+RUN [[ $(uname -m) == "x86_64" ]] && ARCH="amd64" || ARCH="arm64" && \
+	curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_V}/gotestsum_${GOTESTSUM_V}_linux_${ARCH}.tar.gz" | \
 	sudo tar -xz -C /usr/local/bin gotestsum && \
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/local/bin v${GOCI_LINT_V}
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -11,17 +11,19 @@ LABEL maintainer="Community & Partner Engineering Team <community-partner@circle
 
 ENV GO_VER="%%VERSION_FULL%%"
 
+USER root
+
 # Install packages needed for CGO
-RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
 		g++ \
 		libc6-dev && \
-	sudo rm -rf /var/lib/apt/lists/* && \
+	rm -rf /var/lib/apt/lists/* && \
 	# Check if we're facing the first minor release issue and adjust if needed
 	if [[ ${GO_VER:(-2)} == ".0" ]]; then \
 	  GO_VER=${GO_VER:0:-2}; \
 	fi && \
 	[[ $(uname -m) == "x86_64" ]] && ARCH="amd64" || ARCH="arm64" && \
-	curl -sSL "https://go.dev/dl/go${GO_VER}.linux-${ARCH}.tar.gz" | sudo tar -xz -C /usr/local/ && \
+	curl -sSL "https://go.dev/dl/go${GO_VER}.linux-${ARCH}.tar.gz" | tar -xz -C /usr/local/ && \
 	mkdir -p /home/circleci/go/bin
 
 # Install related tools
@@ -29,8 +31,10 @@ ENV GOTESTSUM_V=1.10.0
 ENV GOCI_LINT_V=1.53.2
 RUN [[ $(uname -m) == "x86_64" ]] && ARCH="amd64" || ARCH="arm64" && \
 	curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_V}/gotestsum_${GOTESTSUM_V}_linux_${ARCH}.tar.gz" | \
-	sudo tar -xz -C /usr/local/bin gotestsum && \
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/local/bin v${GOCI_LINT_V}
+	tar -xz -C /usr/local/bin gotestsum && \
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v${GOCI_LINT_V}
 
 ENV GOPATH /home/circleci/go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+
+USER circleci

--- a/manifest
+++ b/manifest
@@ -4,3 +4,4 @@ repository=go
 parent=base
 variants=(node browsers)
 namespace=cimg
+arm64=1


### PR DESCRIPTION
# Description
Add arm64 support to the cimg/go image by using buildx to build multi arch images.

The majority of the work actually lives in the cimg-shared repo which is where the build commands are generated:

https://github.com/CircleCI-Public/cimg-shared/pull/83
https://github.com/CircleCI-Public/cimg-shared/pull/84

The main change to the Dockerfile here is an architecture check and switch to the `USER` directive. `sudo` in buildx builds generally causes errors when running Docker on linux.

See also changes to cimg-orb:

https://github.com/CircleCI-Public/cimg-orb/pull/51

Note: The browsers variant does not build for arm64, only amd64, due to a limitation with selenium server. We will address this in the future, once arm64 support is rolled out to the majority of images

Test build with buildx: 

# Reasons
To build multi architecture images and allow cimg/go to run on arm64 natively

# Checklist

Please check through the following before opening your PR. Thank you!

- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
