### PR TITLE
Use the Q3 base image

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -5,7 +5,7 @@
 # By policy, the base image tag should be a quarterly tag unless there's a 
 # specific reason to use a different one. This means January, April, July, or 
 # October.
-FROM cimg/%%PARENT%%:2023.04
+FROM cimg/%%PARENT%%:2023.07
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 


### PR DESCRIPTION
This image should now be using the July 2023 base image according to policy.