### PR TITLE
Publish v1.21.0 [release]

### DIFF
--- a/1.21/Dockerfile
+++ b/1.21/Dockerfile
@@ -2,10 +2,10 @@
 
 # Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
 
-# By policy, the base image tag should be a quarterly tag unless there's a 
-# specific reason to use a different one. This means January, April, July, or 
+# By policy, the base image tag should be a quarterly tag unless there's a
+# specific reason to use a different one. This means January, April, July, or
 # October.
-FROM cimg/base:2023.04
+FROM cimg/base:2023.07
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
@@ -20,13 +20,16 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	curl -sSL "https://go.dev/dl/go${GO_VER}.linux-${ARCH}.tar.gz" | sudo tar -xz -C /usr/local/ && \
 	mkdir -p /home/circleci/go/bin
 
+ENV GOPATH /home/circleci/go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+
 # Install related tools
 ENV GOTESTSUM_V=1.10.1
-ENV GOCI_LINT_V=1.53.3
+ENV GOCI_LINT_V=1.54.2
+ENV GOVULNCHECK_V=1.0.0
+
 RUN [[ $(uname -m) == "x86_64" ]] && ARCH="amd64" || ARCH="arm64" && \
 	curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_V}/gotestsum_${GOTESTSUM_V}_linux_${ARCH}.tar.gz" | \
 	sudo tar -xz -C /usr/local/bin gotestsum && \
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/local/bin v${GOCI_LINT_V}
-
-ENV GOPATH /home/circleci/go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/local/bin v${GOCI_LINT_V} && \
+	go install "golang.org/x/vuln/cmd/govulncheck@v${GOVULNCHECK_V}" && go clean -cache -modcache && rm -rf "${GOPATH}/pkg"

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -2,8 +2,8 @@
 
 # Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
 
-# By policy, the base image tag should be a quarterly tag unless there's a 
-# specific reason to use a different one. This means January, April, July, or 
+# By policy, the base image tag should be a quarterly tag unless there's a
+# specific reason to use a different one. This means January, April, July, or
 # October.
 FROM cimg/%%PARENT%%:2023.07
 
@@ -25,7 +25,7 @@ ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
 # Install related tools
 ENV GOTESTSUM_V=1.10.1
-ENV GOCI_LINT_V=1.53.3
+ENV GOCI_LINT_V=1.54.2
 ENV GOVULNCHECK_V=1.0.0
 
 RUN [[ $(uname -m) == "x86_64" ]] && ARCH="amd64" || ARCH="arm64" && \


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
Re-release Go 1.21 due to issues raised in this [PR](https://github.com/CircleCI-Public/cimg-go/pull/249) pertaining to the release of 1.21 and breaking changes related to upstream packages for go-critic, kubernetes, and gocilint

# Reasons
Please provide reasoning for these changes and how this PR achieves them.

- Provided feedback on the PR and gave time for a rebase on the branch. Incorporated their PR so they get contribution credit
- Per my comments on the PR, the breaking changes should necessitate a re-release to prevent breaking builds due to the linter

If applicable, include a link to the related GitHub issue that this PR will close.

# Checklist

Please check through the following before opening your PR. Thank you!

- [ ] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
