### PR TITLE
bump orb; remove boolean check params

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  cimg: circleci/cimg@0.5.1
+  cimg: circleci/cimg@0.5.2
   slack: circleci/slack@4.12.1
   gh: circleci/github-cli@2.2.0
 
@@ -22,8 +22,6 @@ workflows:
       not: << pipeline.parameters.cron >>
     jobs:
       - cimg/build-and-deploy:
-          check-directory: true
-          check-file: false
           docker-namespace: ccitest
           docker-repository: go
           publish-branch: main


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
A brief description of the changes in this PR.
bump orb version
