### PR TITLE
chore: upgrade resource-class from medium to large

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ workflows:
       not: << pipeline.parameters.cron >>
     jobs:
       - cimg/build-and-deploy:
+          resource-class: large
           docker-namespace: ccitest
           docker-repository: go
           publish-branch: main


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
Docker building uses a lot of CPU  

# Reasons
![image](https://github.com/CircleCI-Public/cimg-go/assets/4774851/d7842752-fb33-4994-abb9-7f31c3876acf)
https://app.circleci.com/pipelines/github/CircleCI-Public/cimg-go/1070/workflows/75d8bdb6-e8ae-4777-8155-3c9a59335862/jobs/1196/resources

# Checklist

Please check through the following before opening your PR. Thank you!

- [ ] I have made changes to the `Dockerfile.template` file only
- [ ] I have not made any manual changes to automatically generated files
- [ ] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [ ] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
