### PR TITLE
Support Go v1.22.2

### DIFF
--- a/1.22/Dockerfile
+++ b/1.22/Dockerfile
@@ -9,7 +9,7 @@ FROM cimg/base:2024.02
 
 LABEL maintainer="CircleCI Execution Team <eng-execution@circleci.com>"
 
-ENV GO_VER="1.22.1"
+ENV GO_VER="1.22.2"
 
 # Install packages needed for CGO
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \

--- a/1.22/browsers/Dockerfile
+++ b/1.22/browsers/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/go:1.22.1-node
+FROM cimg/go:1.22.2-node
 
 LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/1.22/node/Dockerfile
+++ b/1.22/node/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/go:1.22.1
+FROM cimg/go:1.22.2
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
@@ -13,7 +13,7 @@ RUN curl -sSL "https://raw.githubusercontent.com/CircleCI-Public/cimg-node/main/
 	rm node.tar.xz nodeAliases.txt && \
 	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 1.22.19
+ENV YARN_VERSION 1.22.29
 RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
 	sudo tar -xzf yarn.tar.gz -C /opt/ && \
 	rm yarn.tar.gz && \

--- a/build-images.sh
+++ b/build-images.sh
@@ -4,9 +4,9 @@ set -eo pipefail
 
 docker context create cimg
 docker buildx create --use cimg
-docker buildx build --platform=linux/amd64,linux/arm64 --file 1.22/Dockerfile -t cimg/go:1.22.1 -t cimg/go:1.22 --push .
-docker buildx build --platform=linux/amd64,linux/arm64 --file 1.22/node/Dockerfile -t cimg/go:1.22.1-node -t cimg/go:1.22-node --push .
-docker buildx build --platform=linux/amd64 --file 1.22/browsers/Dockerfile -t cimg/go:1.22.1-browsers -t cimg/go:1.22-browsers --push .
+docker buildx build --platform=linux/amd64,linux/arm64 --file 1.22/Dockerfile -t cimg/go:1.22.2 -t cimg/go:1.22 --push .
+docker buildx build --platform=linux/amd64,linux/arm64 --file 1.22/node/Dockerfile -t cimg/go:1.22.2-node -t cimg/go:1.22-node --push .
+docker buildx build --platform=linux/amd64 --file 1.22/browsers/Dockerfile -t cimg/go:1.22.2-browsers -t cimg/go:1.22-browsers --push .
 docker buildx build --platform=linux/amd64,linux/arm64 --file 1.21/Dockerfile -t cimg/go:1.21.8 -t cimg/go:1.21 --push .
 docker buildx build --platform=linux/amd64,linux/arm64 --file 1.21/node/Dockerfile -t cimg/go:1.21.8-node -t cimg/go:1.21-node --push .
 docker buildx build --platform=linux/amd64 --file 1.21/browsers/Dockerfile -t cimg/go:1.21.8-browsers -t cimg/go:1.21-browsers --push .


### PR DESCRIPTION
# Description
Need to release cimg 1.22.2. asap.



# Reasons
Golang 1.22.1 has major vulnerability https://x.com/golang/status/1775553531564445808?s=20

# Checklist
- [-] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [ ] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
