### PR TITLE
chore: disable golang telemetry

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -20,8 +20,11 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	curl -sSL "https://go.dev/dl/go${GO_VER}.linux-${ARCH}.tar.gz" | sudo tar -xz -C /usr/local/ && \
 	mkdir -p /home/circleci/go/bin
 
-ENV GOPATH /home/circleci/go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+ENV GOPATH="/home/circleci/go"
+ENV PATH="$GOPATH/bin:/usr/local/go/bin:$PATH"
+
+# disable telemetry (in a version-independent way)
+go run golang.org/x/telemetry/cmd/gotelemetry@latest off
 
 # Install related tools
 # renovate: datasource=github-releases depName=gotestyourself/gotestsum


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
Disable golang telemetry collection in preparation to release `cimg/go:1.23`

# Reasons
Please provide reasoning for these changes and how this PR achieves them.

If applicable, include a link to the related GitHub issue that this PR will close.

# Checklist

Please check through the following before opening your PR. Thank you!

- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [ ] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
