### PR TITLE
chore: use latest ENV declaration syntax

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -20,8 +20,8 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 	curl -sSL "https://go.dev/dl/go${GO_VER}.linux-${ARCH}.tar.gz" | sudo tar -xz -C /usr/local/ && \
 	mkdir -p /home/circleci/go/bin
 
-ENV GOPATH /home/circleci/go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+ENV GOPATH="/home/circleci/go"
+ENV PATH="$GOPATH/bin:/usr/local/go/bin:$PATH"
 
 # Install related tools
 # renovate: datasource=github-releases depName=gotestyourself/gotestsum


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
This resolves one of the docker image build warnings present in the automated image release CI workflow by moving to the latest supported `Dockerfile` syntax for declaring environment variables.

# Reasons
Reduce the amount of noise in the build process for new images.

# Checklist

Please check through the following before opening your PR. Thank you!

- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
