### PR TITLE
feat: add Task (taskfile.dev) to image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - run:
           name: Install latest QEMU
-          command: sudo apt-get install qemu-system
+          command: sudo apt-get update && sudo apt-get install qemu-system
       - run:
           name: Register binfmt for supported platforms
           command: docker run --privileged --rm tonistiigi/binfmt --install all

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -30,9 +30,13 @@ ENV GOTESTSUM_VERSION=1.12.0
 ENV GOCI_LINT_VERSION=1.60.1
 # renovate: datasource=github-releases depName=golang/vuln
 ENV GOVULNCHECK_VERSION=1.1.3
+# renovate: datasource=github-releases depName=go-task/task
+ENV TASK_VERSION=3.40.1
 
 RUN [[ $(uname -m) == "x86_64" ]] && ARCH="amd64" || ARCH="arm64" && \
 	curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_VERSION}/gotestsum_${GOTESTSUM_VERSION}_linux_${ARCH}.tar.gz" | \
 	sudo tar -xz -C /usr/local/bin gotestsum && \
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/local/bin v${GOCI_LINT_VERSION} && \
-	go install "golang.org/x/vuln/cmd/govulncheck@v${GOVULNCHECK_VERSION}" && go clean -cache -modcache && rm -rf "${GOPATH}/pkg"
+	go install "golang.org/x/vuln/cmd/govulncheck@v${GOVULNCHECK_VERSION}" && go clean -cache -modcache && rm -rf "${GOPATH}/pkg" && \
+	curl -sSfL "https://github.com/go-task/task/releases/download/v${TASK_VERSION}/task_linux_${ARCH}.tar.gz" | \
+	sudo tar -xz -C /usr/local/bin task


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
Adds Task (https://taskfile.dev) to the Dockerfile.template, to be installed when next the image is built and released.

# Reasons
This provides a simple task runner that is useful for standardizing various project tasks.

# Checklist

Please check through the following before opening your PR. Thank you!

- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
