### PR TITLE
Add a version with ubuntu22 for go 1.24.5

### DIFF
--- a/1.24-ubuntu22/Dockerfile
+++ b/1.24-ubuntu22/Dockerfile
@@ -1,0 +1,42 @@
+# vim:set ft=dockerfile:
+
+# Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
+
+# By policy, the base image tag should be a quarterly tag unless there's a
+# specific reason to use a different one. This means January, April, July, or
+# October.
+FROM cimg/base:2025.04
+
+LABEL maintainer="CircleCI Execution Team <eng-execution@circleci.com>"
+
+ENV GO_VER="1.24.5"
+
+# Install packages needed for CGO
+RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+		g++ \
+		libc6-dev && \
+	sudo rm -rf /var/lib/apt/lists/* && \
+	[[ $(uname -m) == "x86_64" ]] && ARCH="amd64" || ARCH="arm64" && \
+	curl -sSL "https://go.dev/dl/go${GO_VER}.linux-${ARCH}.tar.gz" | sudo tar -xz -C /usr/local/ && \
+	mkdir -p /home/circleci/go/bin
+
+ENV GOPATH="/home/circleci/go"
+ENV PATH="$GOPATH/bin:/usr/local/go/bin:$PATH"
+
+# Install related tools
+# renovate: datasource=github-releases depName=gotestyourself/gotestsum
+ENV GOTESTSUM_VERSION=1.12.0
+# renovate: datasource=github-releases depName=golangci/golangci-lint
+ENV GOCI_LINT_VERSION=1.64.5
+# renovate: datasource=github-releases depName=golang/vuln
+ENV GOVULNCHECK_VERSION=1.1.4
+# renovate: datasource=github-releases depName=go-task/task
+ENV TASK_VERSION=3.40.1
+
+RUN [[ $(uname -m) == "x86_64" ]] && ARCH="amd64" || ARCH="arm64" && \
+	curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_VERSION}/gotestsum_${GOTESTSUM_VERSION}_linux_${ARCH}.tar.gz" | \
+	sudo tar -xz -C /usr/local/bin gotestsum && \
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/local/bin v${GOCI_LINT_VERSION} && \
+	go install "golang.org/x/vuln/cmd/govulncheck@v${GOVULNCHECK_VERSION}" && go clean -cache -modcache && rm -rf "${GOPATH}/pkg" && \
+	curl -sSfL "https://github.com/go-task/task/releases/download/v${TASK_VERSION}/task_linux_${ARCH}.tar.gz" | \
+	sudo tar -xz -C /usr/local/bin task

--- a/1.24-ubuntu22/browsers/Dockerfile
+++ b/1.24-ubuntu22/browsers/Dockerfile
@@ -1,0 +1,62 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/go:1.24.5-node-ubuntu22
+
+LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Install Selenium
+ENV SELENIUM_VER=3.141.59
+RUN curl -sSL -o selenium-server-standalone-${SELENIUM_VER}.jar "https://selenium-release.storage.googleapis.com/${SELENIUM_VER%.*}/selenium-server-standalone-${SELENIUM_VER}.jar" && \
+    sudo cp selenium-server-standalone-${SELENIUM_VER}.jar /usr/local/bin/selenium.jar && \
+    rm selenium-server-standalone-${SELENIUM_VER}.jar
+
+RUN sudo apt-get update && \
+	sudo apt-get install --yes --no-install-recommends \
+		xvfb \
+	&& \
+    # Install Java only if it's not already available
+    # Java is installed for Selenium
+    if ! command -v java > /dev/null; then \
+        echo "Java not found in parent image, installing..." && \
+        sudo apt-get install -y --no-install-recommends --no-upgrade openjdk-11-jre; \
+    fi && \
+	sudo rm -rf /var/lib/apt/lists/*
+
+# Below is setup to allow xvfb to start when the container starts up.
+# The label in particular allows this image to override what CircleCI does
+# when booting the image.
+LABEL com.circleci.preserve-entrypoint=true
+ENV DISPLAY=":99"
+#RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint && \
+#	chmod +x /tmp/entrypoint && \
+#	sudo mv /tmp/entrypoint /docker-entrypoint.sh
+RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' | sudo tee /docker-entrypoint.sh && \
+	sudo chmod +x /docker-entrypoint.sh
+
+# Install a single version of Firefox. This isn't intended to be a regularly
+# updated thing. Instead, if this version of Firefox isn't what the end user
+# wants they should install a different version via the Browser Tools Orb.
+#
+# Canonical made a major technology change in how Firefox is installed from
+# Ubuntu 21.10 and up. The general CI space doesn't seem to be ready for a snap
+# based Firefox right now so we are installing it from the Mozilla PPA.
+RUN echo 'Package: *' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
+	echo 'Pin: release o=LP-PPA-mozillateam' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
+	echo 'Pin-Priority: 1001' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
+	sudo add-apt-repository --yes ppa:mozillateam/ppa && \
+	sudo apt-get install --no-install-recommends --yes firefox && \
+	sudo rm -rf /var/lib/apt/lists/* && \
+	firefox --version
+
+# Install a single version of Google Chrome Stable. This isn't intended to be a
+# regularly updated thing. Instead, if this version of Chrome isn't what the
+# end user wants they should install a different version via the Browser Tools
+# Orb.
+RUN wget -q -O - "https://dl.google.com/linux/linux_signing_key.pub" | sudo apt-key add - && \
+	echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list && \
+	sudo apt-get update && \
+	sudo apt-get install google-chrome-stable && \
+	sudo rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/bin/sh"]

--- a/1.24-ubuntu22/node/Dockerfile
+++ b/1.24-ubuntu22/node/Dockerfile
@@ -1,0 +1,16 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/go:1.24.5-ubuntu22
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Dockerfile will pull the latest LTS release from cimg-node.
+RUN curl -sSL "https://raw.githubusercontent.com/CircleCI-Public/cimg-node/main/ALIASES" -o nodeAliases.txt && \
+	NODE_VERSION=$(grep "lts" ./nodeAliases.txt | cut -d "=" -f 2-) && \
+	[[ $(uname -m) == "x86_64" ]] && ARCH="x64" || ARCH="arm64" && \
+	curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${ARCH}.tar.xz" && \
+	sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
+	rm node.tar.xz nodeAliases.txt && \
+	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+RUN sudo npm install -g yarn pnpm

--- a/build-images.sh
+++ b/build-images.sh
@@ -10,3 +10,6 @@ docker buildx build --platform=linux/amd64 --file 1.24/browsers/Dockerfile -t ci
 docker buildx build --platform=linux/amd64,linux/arm64 --file 1.23/Dockerfile -t cimg/go:1.23.11 -t cimg/go:1.23 --push .
 docker buildx build --platform=linux/amd64,linux/arm64 --file 1.23/node/Dockerfile -t cimg/go:1.23.11-node -t cimg/go:1.23-node --push .
 docker buildx build --platform=linux/amd64 --file 1.23/browsers/Dockerfile -t cimg/go:1.23.11-browsers -t cimg/go:1.23-browsers --push .
+docker buildx build --platform=linux/amd64,linux/arm64 --file 1.24-ubuntu22/Dockerfile -t cimg/go:1.24.5-ubuntu22 -t cimg/go:1.24-ubuntu22 --push .
+docker buildx build --platform=linux/amd64,linux/arm64 --file 1.24/node/Dockerfile -t cimg/go:1.24.5-node-ubuntu22 -t cimg/go:1.24-node-ubuntu22 --push .
+docker buildx build --platform=linux/amd64 --file 1.24/browsers/Dockerfile -t cimg/go:1.24.5-browsers-ubuntu22 -t cimg/go:1.24-browsers-ubuntu22 --push .


### PR DESCRIPTION
This creates a new version for go 1.24.5 but using ubuntu 22