### PR TITLE
patch: bump cimg/base from 2026.03 to 2026.07

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -5,7 +5,7 @@
 # By policy, the base image tag should be a quarterly tag unless there's a
 # specific reason to use a different one. This means January, April, July, or
 # October.
-FROM cimg/base:2026.03
+FROM cimg/base:2026.07
 
 LABEL maintainer="CircleCI Execution Team <eng-execution@circleci.com>"
 


### PR DESCRIPTION
There once was an image from Docker / whose CVEs made it a shocker.

Updates `cimg/base` from `2026.03` to `2026.07` in `Dockerfile.template`.

No functional changes. Just security.

---
*-- sir-patches-alot*