### PR TITLE
Ignore all cimg Dockerfiles in Renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,12 +4,7 @@
     'config:recommended',
   ],
   ignorePaths: [
-    '1.17/',
-    '1.18/',
-    '1.19/',
-    '1.20/',
-    '1.21/',
-    '1.22/',
+    '1.*/**',
   ],
   customManagers: [
     {


### PR DESCRIPTION
Generalizes the `ignorePaths` so that we don't have to keep updating them when a new Go version is released.
